### PR TITLE
Persist libraries to workspace on build_backend

### DIFF
--- a/src/jobs/build_backend.yml
+++ b/src/jobs/build_backend.yml
@@ -59,6 +59,7 @@ steps:
       paths:
         - bin
         - app/core
+        - app/libraries
         - app/modules/contrib
         - app/profiles/contrib
         - app/themes/contrib


### PR DESCRIPTION
Some composer deps can live here.